### PR TITLE
feat: add reauthentication

### DIFF
--- a/src/usr/local/emhttp/plugins/tailscale/include/Pages/Info.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/Pages/Info.php
@@ -32,6 +32,7 @@ echo Utils::printRow($tr->tr("info.online"), $tailscaleStatusInfo->Online);
 echo Utils::printRow($tr->tr("info.key_expire"), $tailscaleStatusInfo->KeyExpiration);
 echo Utils::printRow($tr->tr("info.tags"), $tailscaleStatusInfo->Tags);
 echo Utils::printRow("{$lockTranslate}: " . $tr->tr("enabled"), $tailscaleStatusInfo->LockEnabled);
+echo Utils::printRow($tr->tr("info.connected_via"), $tailscaleInfo->connectedViaTS() ? $tr->tr("yes") : $tr->tr("no"));
 
 if ($tailscaleStatusInfo->LockInfo != null) {
     echo Utils::printRow("{$lockTranslate}: " . $tr->tr("info.lock.signed"), $tailscaleStatusInfo->LockInfo->LockSigned);

--- a/src/usr/local/emhttp/plugins/tailscale/include/Pages/Settings.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/Pages/Settings.php
@@ -211,7 +211,7 @@ if ($tailscaleConfig->Enable) {
 
     async function expireTailscaleKeyNow() {
         $('div.spinner.fixed').show('fast');
-        var res = await $.post('/plugins/tailscale/include/data/Config.php',{action: 'expire-now'});
+        var res = await $.post('/plugins/tailscale/include/data/Config.php',{action: 'expire-key'});
         location.reload();
     }
 </script>

--- a/src/usr/local/emhttp/plugins/tailscale/include/Tailscale/Info.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/Tailscale/Info.php
@@ -398,4 +398,9 @@ class Info
 
         return "";
     }
+
+    public function connectedViaTS(): bool
+    {
+        return in_array($_SERVER['SERVER_ADDR'] ?? "", $this->status->TailscaleIPs ?? array());
+    }
 }

--- a/src/usr/local/emhttp/plugins/tailscale/include/Tailscale/Info.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/Tailscale/Info.php
@@ -375,7 +375,7 @@ class Info
     {
         $exitNodes = array();
 
-        foreach ($this->status->Peer as $node => $status) {
+        foreach (($this->status->Peer ?? array()) as $node => $status) {
             if ($status->ExitNodeOption ?? false) {
                 $nodeName = $status->DNSName;
                 if (isset($status->Location->City)) {
@@ -390,7 +390,7 @@ class Info
 
     public function getCurrentExitNode(): string
     {
-        foreach ($this->status->Peer as $node => $status) {
+        foreach (($this->status->Peer ?? array()) as $node => $status) {
             if ($status->ExitNode ?? false) {
                 return $status->ID;
             }

--- a/src/usr/local/emhttp/plugins/tailscale/include/Tailscale/LocalAPI.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/Tailscale/LocalAPI.php
@@ -79,4 +79,9 @@ class LocalAPI
         $body = ["NodeKey" => $key];
         $this->tailscaleLocalAPI("v0/tka/sign", APIMethods::POST, (object) $body);
     }
+
+    public function expireKey(): void
+    {
+        $this->tailscaleLocalAPI('v0/set-expiry-sooner?expiry=0', APIMethods::POST);
+    }
 }

--- a/src/usr/local/emhttp/plugins/tailscale/include/data/Config.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/data/Config.php
@@ -232,6 +232,12 @@ try {
 
             $localAPI->patchPref("AdvertiseRoutes", array_values($advertisedRoutes));
             break;
+        case 'expire-key':
+            if ($tailscaleInfo->connectedViaTS()) {
+                throw new \Exception("Cannot expire key while connected via Tailscale");
+            }
+            $localAPI->expireKey();
+            break;
         case 'exit-node':
             if ( ! isset($_POST['node'])) {
                 throw new \Exception("Missing node parameter");

--- a/src/usr/local/emhttp/plugins/tailscale/include/data/Config.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/data/Config.php
@@ -236,6 +236,7 @@ try {
             if ($tailscaleInfo->connectedViaTS()) {
                 throw new \Exception("Cannot expire key while connected via Tailscale");
             }
+            Utils::logmsg("Expiring node key");
             $localAPI->expireKey();
             break;
         case 'exit-node':

--- a/src/usr/local/emhttp/plugins/tailscale/locales/en_US.json
+++ b/src/usr/local/emhttp/plugins/tailscale/locales/en_US.json
@@ -44,6 +44,7 @@
         "erase": "Erase Tailscale Configuration",
         "diagnostics": "Plugin Diagnostics",
         "donate": "Donate",
+        "reauthenticate": "Reauthenticate",
         "context": {
             "unraid_listen": "Configures Unraid services (SSH, WebGUI, SMB, etc.) to listen on Tailscale addresses.",
             "ip_forward": "Sets net.ipv4.ip_forward and net.ipv6.conf.all.forwarding to 1 in sysctl. This change occurs immediately when being enabled.",
@@ -58,7 +59,8 @@
             "ignore": "If set to ignore, the plugin will not modify the setting",
             "outbound_network": "These settings only apply to outbound network traffic from Unraid or running containers. They do not affect advertised routes, exit nodes, or the ability to access Unraid via MagicDNS. These should generally be left off unless specifically needed. Turning these on may cause network issues.",
             "save": "Tailscale will be restarted when changes are applied",
-            "donate": "If this plugin helps you, please consider donating."
+            "donate": "If this plugin helps you, please consider donating.",
+            "reauthenticate": "Force a Tailscale reauthentication. This will disconnect Tailscale until the authentication is completed."
         }
     },
     "help": {
@@ -97,6 +99,7 @@
         "use_exit_node": "Use Exit Node",
         "exit_node_local": "Allow LAN Access while using Exit Node",
         "unapproved": "Needs approval in admin console",
+        "connected_via": "Connected via Tailscale",
         "lock": {
             "node_key": "Node Key",
             "public_key": "Public Key",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Reauthenticate" button to the Tailscale settings page, allowing users to force reauthentication.
  - Status information now displays whether the connection is established via Tailscale.
- **Improvements**
  - Critical buttons such as "Erase" and "Reauthenticate" are now automatically disabled when connected via Tailscale to prevent accidental disconnection.
- **Localization**
  - Added new labels and descriptions for the "Reauthenticate" action and connection status in the English interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->