### PR TITLE
fix: ignore USE_SSL since the WebGUI ignores it

### DIFF
--- a/src/usr/local/emhttp/plugins/tailscale/include/Tailscale/System.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/Tailscale/System.php
@@ -59,12 +59,8 @@ class System
 
         $httpPort = isset($ident_config['PORT']) && is_scalar($ident_config['PORT'])
                      ? intval($ident_config['PORT']) : 80;
-        $httpsPort = -1;
-
-        if (($ident_config['USE_SSL'] ?? "no") != "no") {
-            $httpsPort = isset($ident_config['PORTSSL']) && is_scalar($ident_config['PORTSSL'])
-                         ? intval($ident_config['PORTSSL']) : 443;
-        }
+        $httpsPort = isset($ident_config['PORTSSL']) && is_scalar($ident_config['PORTSSL'])
+                     ? intval($ident_config['PORTSSL']) : 443;
 
         $localAPI    = new LocalAPI();
         $serveConfig = $localAPI->getServeConfig();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the logic for determining the HTTPS port, ensuring consistent behavior regardless of SSL configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->