### PR TITLE
fix: update modal link

### DIFF
--- a/src/usr/local/emhttp/plugins/tailscale/include/Pages/Settings.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/Pages/Settings.php
@@ -273,7 +273,7 @@ function showSettingWarning(message, element) {
     };
 
     const links = {
-        'funnel': "https://forums.unraid.net/",
+        'funnel': "https://docs.unraid.net/unraid-os/manual/security/tailscale/",
         'subnet': "",
         'dns': ""
     };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the help link in the Tailscale settings warning to direct users to the official Unraid Tailscale security documentation instead of the forums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->